### PR TITLE
README.mdのリンク切れ対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nouhau
 Google Cloud Platformのノウハウを共有するRepository
-もし、あなたがGCPを初めて利用する場合、 https://github.com/gcpug/nouhau/tree/master/general/poem/link が役立つかもしれません。
+もし、あなたがGCPを初めて利用する場合、 https://github.com/gcpug/nouhau/tree/master/general/note/link が役立つかもしれません。
 
 ## dir構成
 


### PR DESCRIPTION
commit 8759a13 のフォルダ名の変更でURLがリンク切れとなっております。
フォルダ名の変更をURLに反映させていただきました。