### PR TITLE
add GAE Go 1.11 Private Repoを含むDeploy

### DIFF
--- a/app-engine/note/gaego111-private-repo-deploy/README.md
+++ b/app-engine/note/gaego111-private-repo-deploy/README.md
@@ -8,14 +8,25 @@ App Engine Go Runtime 1.11から、Deployする時にGooble Cloud Buildを利用
 暗黙的に実行されるCloud BuildのJobには干渉できないので、Secret Tokenを渡したりすることもできない。
 そのため、go getしないようにvendorを用意する必要がある。
 
-以下のような形で、vendorを作成し、 `go.mod` `go.sum` を削除しておけば、Cloud Buildの中でgo getが走らない。
+### .gcloudignore
+
+Cloud Build上でgo modulesが動かないように `.gcloudignore` に `go.mod` , `go,sum` を追加しておく 
+
+```
+go.mod
+go.sum
+```
+
+`.gcloudignore` に `vendor` があると、Deployされないので、注意
+
+### Deploy
+
+vendorを作成し、 `GO111MODULE=off` を設定した状態で、 `gcloud app deploy` を行う
 
 ```
 go mod vendor
-rm go.mod go.sum
+GO111MODULE=off gcloud app deploy .
 ```
-
-`go.mod` `go.sum` に関しては `app.yaml` と同じ階層になければ、消さなくてもよいという情報もあるが、細かいディレクトリ構成による差異については未検証。
 
 ## Refs
 

--- a/app-engine/note/gaego111-private-repo-deploy/README.md
+++ b/app-engine/note/gaego111-private-repo-deploy/README.md
@@ -1,0 +1,22 @@
+# App Engine Standard Go 1.11 Private Repoを参照したDeploy
+
+tag:["google-app-engine", "Go"]
+
+App Engine Go Runtime 1.11から、Deployする時にGooble Cloud Buildを利用するようになっている。
+`gcloud app deploy` を実行すると、暗黙的にCloud BuildにSubmitされる。
+その時、go modulesを利用していると、go getが実行されるが、go getの対象にPrivate Repositoryがあると、getに失敗し `error loading module requirements` というメッセージが出る。
+暗黙的に実行されるCloud BuildのJobには干渉できないので、Secret Tokenを渡したりすることもできない。
+そのため、go getしないようにvendorを用意する必要がある。
+
+以下のような形で、vendorを作成し、 `go.mod` `go.sum` を削除しておけば、Cloud Buildの中でgo getが走らない。
+
+```
+go mod vendor
+rm go.mod go.sum
+```
+
+`go.mod` `go.sum` に関しては `app.yaml` と同じ階層になければ、消さなくてもよいという情報もあるが、細かいディレクトリ構成による差異については未検証。
+
+## Refs
+
+* [go modulesを利用するとデプロイが遅くなる問題の解決策](https://github.com/gcpug/nouhau/issues/87)


### PR DESCRIPTION
Private Repoを依存関係に持つ、GAE Go 1.11のアプリをDeployしようとすると、ハマったので解決方法を書いた。

refs #87